### PR TITLE
fix: add fallback seo tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,12 @@
     <meta http-equiv="X-UA-Compatible" content="ie-edge" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="og:title" content="Fav — Modern Favicon Generator" />
+    <meta name="og:description" content="Generate compact favicon set for your websites within few clicks." />
     <meta name="og:image" content="/og-banner.png" />
+    <meta name="og:url" content="https://fav.namchee.dev" />
     <meta name="og:type" content="website" />
+    <meta name="twitter:description" content="Generate compact favicon set for your websites within few clicks." />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lakban_hitam" />
     <meta name="theme-color" content="#3E63DD" />
@@ -16,6 +20,7 @@
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="canonical" href="https://fav.namchee.dev" />
     <title>Fav &mdash; Modern Favicon Generator</title>
+    <meta name="description" content="Generate compact favicon set for your websites within few clicks." />
   </head>
   <body>
     <div id="app">


### PR DESCRIPTION
## Overview

This pull request adds static fallback SEO tags, as Vite is **not** a static-site generator. Now, direct links should work correctly.